### PR TITLE
Fix comma bug in JSON enricher

### DIFF
--- a/src/main/java/io/qntfy/nifi/processors/GetRedisEnrichment.java
+++ b/src/main/java/io/qntfy/nifi/processors/GetRedisEnrichment.java
@@ -167,8 +167,10 @@ public class GetRedisEnrichment extends AbstractProcessor {
                 String uuid = flowFile.getAttribute("uuid");
                 String flowFileKey = source + ":" + uuid;
                 
-                // if not all the values exist
-                if (jedis.hlen(flowFileKey) != requiredEnrichments) {
+                if (requiredEnrichments == 0) {
+                    logger.info("Transferred {} to 'success'", new Object[] {flowFile});
+                    session.transfer(flowFile, REL_SUCCESS);
+                } else if (jedis.hlen(flowFileKey) != requiredEnrichments) {
                     String attemptsStr = flowFile.getAttribute(attemptsAttribute);
                     Integer attempts = (attemptsStr == null) ? 0 : Integer.valueOf(attemptsStr);
                     attempts += 1;

--- a/src/main/java/io/qntfy/nifi/util/StreamingJSONAppender.java
+++ b/src/main/java/io/qntfy/nifi/util/StreamingJSONAppender.java
@@ -15,6 +15,7 @@ import org.apache.nifi.processor.io.StreamCallback;
 public class StreamingJSONAppender implements StreamCallback {
     private final String field;
     private final String content;
+    private final boolean hasContent;
     private final Stack<String> depth = new Stack<>();
     private static final String A = "A";
     private static final String O = "O";
@@ -27,6 +28,12 @@ public class StreamingJSONAppender implements StreamCallback {
             throw new IllegalArgumentException("content must be valid JSON");
         }
         this.content = content.substring(start + 1, end);
+        if (this.content.replaceAll("\\s", "").length() == 0) {
+            this.hasContent = false;
+        } else {
+            this.hasContent = true;
+        }
+        
     }
     
     private static void writeComma(Event prev, OutputStream out) throws IOException {
@@ -89,7 +96,7 @@ public class StreamingJSONAppender implements StreamCallback {
                     str = "\"" + StringEscapeUtils.escapeJson(this.field) + "\": {" + this.content + "}";
                     out.write(str.getBytes());
                 }
-                if (insideTarget && depthPastTarget == 1) {
+                if (insideTarget && depthPastTarget == 1 && hasContent) {
                     writeComma(prev, out);
                     out.write(this.content.getBytes());
                     insideTarget = false;

--- a/src/test/java/io/qntfy/nifi/util/JSONFlowFileEnricherImplTest.java
+++ b/src/test/java/io/qntfy/nifi/util/JSONFlowFileEnricherImplTest.java
@@ -17,4 +17,12 @@ public class JSONFlowFileEnricherImplTest {
         String expectedJson = "{\"jsonKey1\": {\"text\": \"json blob 1\"}, \"jsonKey2\": {\"text\": \"json blob 2\"}}";
         assertEquals("Combined json is malformed.", expectedJson, combinedJson);
     }
+    
+    @Test
+    public void makeJsonFromEmptyMapOfJsonsTest() {
+        Map<String, String> jsonMap = new TreeMap<>();
+        String combinedJson = JSONFlowFileEnricherImpl.makeJsonFromMapOfJsons(jsonMap);
+        String expectedJson = "{}";
+        assertEquals("Combined json is malformed.", expectedJson, combinedJson);
+    }
 }

--- a/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
+++ b/src/test/java/io/qntfy/nifi/util/StreamingJSONAppenderTest.java
@@ -29,6 +29,21 @@ public class StreamingJSONAppenderTest {
     }
     
     @Test
+    public void testEmptyAppendToExistingEnrichmentField() throws IOException {
+        String data = "{}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {\"existing\": \"value3\"}}";
+        String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {\"existing\": \"value3\"}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    @Test
     public void testMultipleEnrichments() throws IOException {
         String data = "{\"spinseeker\": {\"text\": \"spinseeker value\"}}";
         StreamingJSONAppender sja = new StreamingJSONAppender("metrics", data);
@@ -94,12 +109,42 @@ public class StreamingJSONAppenderTest {
     }
     
     @Test
+    public void testAppendToExistingEmptyEnrichmentFieldEmpty() throws IOException {
+        String data = "{}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {}}";
+        String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    @Test
     public void testAddNewEnrichmentField() throws IOException {
         String data = "{\"test\": \"value\"}";
         StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
         
         String input = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}}";
         String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {\"test\": \"value\"}}";
+        
+        InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
+        OutputStream os = new ByteArrayOutputStream();
+        sja.process(is, os);
+        
+        assertEquals("JSON string is malformed.", output, os.toString());
+    }
+    
+    @Test
+    public void testAddNewEnrichmentFieldEmpty() throws IOException {
+        String data = "{}";
+        StreamingJSONAppender sja = new StreamingJSONAppender("enrichment", data);
+        
+        String input = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}}";
+        String output = "{\"test\": {\"test2\": \"ABC\", \"test1\": 123}, \"enrichment\": {}}";
         
         InputStream is = new ByteArrayInputStream(input.getBytes(Charset.defaultCharset()));
         OutputStream os = new ByteArrayOutputStream();


### PR DESCRIPTION
Fix the comma bug in JSON enricher by checking to see if the JSON enrichment is none. If none, nothing is added to the enrichment JSON. This is further prevented against by adding a short-circuit: skipping the enrichment process entirely (and passing the message along) in the case that there are no enrichments expected.
